### PR TITLE
HYDRATOR-1495 add rate limit to kafka streaming source

### DIFF
--- a/docs/Kafka-streamingsource.md
+++ b/docs/Kafka-streamingsource.md
@@ -62,6 +62,8 @@ If set, this field must be present in the schema property and must be an int.
 If this is not set, no offset field will be added to output records.
 If set, this field must be present in the schema property and must be a long.
 
+**maxRatePerPartition:** Maximum number of records to read per second per partition. Defaults to 1000.
+
 
 Example
 -------

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>co.cask.hydrator</groupId>
   <artifactId>kafka-plugins</artifactId>
-  <version>1.7.0-0.8.2.2-SNAPSHOT</version>
+  <version>1.7.0-SNAPSHOT-0.8.2.2</version>
 
   <licenses>
     <license>
@@ -66,7 +66,7 @@
     <kafka.version>0.8.2.2</kafka.version>
     <hadoop.version>2.3.0</hadoop.version>
     <!-- properties for script build step that creates the config files for the artifacts -->
-    <app.parents>system:cdap-data-streams[4.1.0,5.0.0),system:cdap-data-pipeline[4.1.0,5.0.0)</app.parents>
+    <app.parents>system:cdap-data-streams[4.2.0-SNAPSHOT,5.0.0),system:cdap-data-pipeline[4.2.0-SNAPSHOT,5.0.0)</app.parents>
     <main.basedir>${project.basedir}</main.basedir>
   </properties>
 

--- a/src/main/java/co/cask/hydrator/plugin/source/KafkaConfig.java
+++ b/src/main/java/co/cask/hydrator/plugin/source/KafkaConfig.java
@@ -113,9 +113,14 @@ public class KafkaConfig extends ReferencePluginConfig implements Serializable {
   @Nullable
   private String offsetField;
 
+  @Description("Max number of records to read per second per partition. 0 means there is no limit. Defaults to 1000.")
+  @Nullable
+  private Integer maxRatePerPartition;
+
   public KafkaConfig() {
     super("");
     defaultInitialOffset = -1L;
+    maxRatePerPartition = 1000;
   }
 
   @VisibleForTesting
@@ -173,6 +178,11 @@ public class KafkaConfig extends ReferencePluginConfig implements Serializable {
   @Nullable
   public String getFormat() {
     return Strings.isNullOrEmpty(format) ? null : format;
+  }
+
+  @Nullable
+  public Integer getMaxRatePerPartition() {
+    return maxRatePerPartition;
   }
 
   public Schema getSchema() {
@@ -331,6 +341,11 @@ public class KafkaConfig extends ReferencePluginConfig implements Serializable {
     getBrokerMap();
     getPartitions();
     getInitialPartitionOffsets(getPartitions());
+
+    if (maxRatePerPartition < 0) {
+      throw new IllegalArgumentException(String.format("Invalid maxRatePerPartition %d. Rate must be 0 or greater.",
+                                                       maxRatePerPartition));
+    }
 
     if (!Strings.isNullOrEmpty(timeField) && !Strings.isNullOrEmpty(keyField) && timeField.equals(keyField)) {
       throw new IllegalArgumentException(String.format(

--- a/src/main/java/co/cask/hydrator/plugin/source/KafkaStreamingSource.java
+++ b/src/main/java/co/cask/hydrator/plugin/source/KafkaStreamingSource.java
@@ -78,6 +78,11 @@ public class KafkaStreamingSource extends ReferenceStreamingSource<StructuredRec
     super.configurePipeline(pipelineConfigurer);
     conf.validate();
     pipelineConfigurer.getStageConfigurer().setOutputSchema(conf.getSchema());
+    if (conf.getMaxRatePerPartition() > 0) {
+      Map<String, String> pipelineProperties = new HashMap<>();
+      pipelineProperties.put("spark.streaming.kafka.maxRatePerPartition", conf.getMaxRatePerPartition().toString());
+      pipelineConfigurer.setPipelineProperties(pipelineProperties);
+    }
   }
 
   @Override

--- a/widgets/Kafka-streamingsource.json
+++ b/widgets/Kafka-streamingsource.json
@@ -66,6 +66,14 @@
           "widget-type": "textbox",
           "label": "Offset Field",
           "name": "offsetField"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Max Rate Per Partition",
+          "name": "maxRatePerPartition",
+          "widget-attributes": {
+            "default": "1000"
+          }
         }
       ]
     },


### PR DESCRIPTION
Adds a config property to rate limit the number of records read
per second per partition.