### PR TITLE
Update travis build to use openjdk7 instead of oraclejdk7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+before_install:
+  - wget http://mirror.cc.columbia.edu/pub/software/apache/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.tar.gz
+  - tar xf apache-maven-3.2.5-bin.tar.gz
+  - export M2_HOME=$PWD/apache-maven-3.2.5
+  - export PATH=$M2_HOME/bin:$PATH
+
 language: java
 
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@
 language: java
 
 jdk:
-  - oraclejdk7
+  - openjdk7
   - oraclejdk8
 
 env:


### PR DESCRIPTION
https://issues.cask.co/browse/CDAP-12192

Without this change, we get errors such as: https://travis-ci.org/hydrator/kafka-plugins/jobs/267842181

See:
https://github.com/travis-ci/travis-ci/issues/7019#issuecomment-316769716
https://github.com/fpavageau/liquigraph/commit/9d60b1e5c1e904078574cbcc6e75bab184fd7076
https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879

One thing to consider is that maybe we should also bump the oraclejdk8 to openjdk8, but that is not strictly required.


Also pinning the maven version, due to [CDAP-12507](https://issues.cask.co/browse/CDAP-12507).