### PR TITLE
bump version to 1.9.0-SNAPSHOT

### DIFF
--- a/kafka-plugins-0.10/pom.xml
+++ b/kafka-plugins-0.10/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <artifactId>kafka-plugins</artifactId>
     <groupId>co.cask.hydrator</groupId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <name>Apache Kafka 0.10 plugins</name>
   <artifactId>kafka-plugins</artifactId>
-  <version>1.8.2-SNAPSHOT-0.10.2.0</version>
+  <version>${project.parent.version}-0.10.2.0</version>
 
   <dependencies>
     <dependency>
@@ -149,11 +149,11 @@
       <plugin>
         <groupId>co.cask</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[5.0.0,6.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[5.0.0,6.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>

--- a/kafka-plugins-0.8/pom.xml
+++ b/kafka-plugins-0.8/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <artifactId>kafka-plugins</artifactId>
     <groupId>co.cask.hydrator</groupId>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <name>Apache Kafka 0.8 plugins</name>
   <artifactId>kafka-plugins</artifactId>
-  <version>1.8.2-SNAPSHOT-0.8.2.2</version>
+  <version>${project.parent.version}-0.8.2.2</version>
 
   <dependencies>
     <dependency>
@@ -133,11 +133,11 @@
       <plugin>
         <groupId>co.cask</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[5.0.0,6.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[5.0.0,6.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <groupId>co.cask.hydrator</groupId>
   <artifactId>kafka-plugins</artifactId>
   <packaging>pom</packaging>
-  <version>1.8.2-SNAPSHOT</version>
+  <version>1.9.0-SNAPSHOT</version>
 
   <licenses>
     <license>
@@ -62,10 +62,17 @@
     </repository>
   </repositories>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <id>sonatype.release</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>4.3.2</cdap.version>
-    <hydrator.version>1.8.2</hydrator.version>
+    <cdap.version>5.0.0</cdap.version>
+    <hydrator.version>2.0.0</hydrator.version>
     <spark1.version>1.6.1</spark1.version>
     <spark2.version>2.2.0</spark2.version>
     <widgets.dir>widgets</widgets.dir>


### PR DESCRIPTION
Also update the parent lower version in preparation of field
level lineage changes that require at least CDAP 5.0.0