### PR TITLE
adding kafka-clients which will help creating consumer with group-id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,11 @@
       <version>${netty-http.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>0.9.0.1</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
using kafka-clients 0.9.0.0 we can create Consumer with a specific/given consumer group id.
Using that way we can add another variable to kafka-plugin source form to have the consumer group id