### PR TITLE
Revert "update cdap dependency"

### DIFF
--- a/kafka-plugins-0.10/pom.xml
+++ b/kafka-plugins-0.10/pom.xml
@@ -182,8 +182,8 @@
         <version>1.0.1</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[5.1.0,7.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[5.1.0,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[5.1.0,6.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[5.1.0,6.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>

--- a/kafka-plugins-0.8/pom.xml
+++ b/kafka-plugins-0.8/pom.xml
@@ -166,8 +166,8 @@
         <version>1.0.1</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[5.1.0,7.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[5.1.0,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[5.1.0,6.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[5.1.0,6.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.0.0-SNAPSHOT</cdap.version>
-    <hydrator.version>2.2.0-SNAPSHOT</hydrator.version>
+    <cdap.version>5.1.0</cdap.version>
+    <hydrator.version>2.1.0</hydrator.version>
     <spark1.version>1.6.1</spark1.version>
     <spark2.version>2.2.0</spark2.version>
     <widgets.dir>widgets</widgets.dir>


### PR DESCRIPTION
Reverts data-integrations/kafka-plugins#44

Reverting to depend on previous version as the plugin does have any new feature which requires them to depend on latest cdap version