### PR TITLE
Add error logs for when kafka server isn't running

### DIFF
--- a/kafka-plugins-0.10/src/main/java/io/cdap/plugin/source/KafkaStreamingSourceUtil.java
+++ b/kafka-plugins-0.10/src/main/java/io/cdap/plugin/source/KafkaStreamingSourceUtil.java
@@ -32,6 +32,7 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
@@ -141,6 +142,10 @@ final class KafkaStreamingSourceUtil {
         context.getSparkStreamingContext(), LocationStrategies.PreferConsistent(),
         ConsumerStrategies.<byte[], byte[]>Subscribe(Collections.singleton(conf.getTopic()), kafkaParams, offsets)
       ).transform(new RecordTransform(conf));
+    } catch (KafkaException e) {
+      LOG.error("Exception occurred while trying to read from kafka topic: {}", e.getMessage());
+      LOG.error("Please verify that the hostname/IPAddress of the kafka server is correct and that it is running.");
+      throw e;
     }
   }
 

--- a/kafka-plugins-0.8/src/main/java/io/cdap/plugin/source/KafkaStreamingSourceUtil.java
+++ b/kafka-plugins-0.8/src/main/java/io/cdap/plugin/source/KafkaStreamingSourceUtil.java
@@ -125,6 +125,11 @@ final class KafkaStreamingSourceUtil {
         MessageAndMetadata.class, kafkaParams, offsets,
         (Function<MessageAndMetadata<byte[], byte[]>, MessageAndMetadata>) in -> in)
         .transform(new RecordTransform(conf));
+    } catch (Exception e) {
+      // getPartitions() throws a ClosedChannelException if kafka connection fails
+      LOG.error("Unable to read from kafka. " +
+                  "Please verify that the hostname/IPAddress of the kafka server is correct and that it is running.");
+      throw e;
     } finally {
       for (SimpleConsumer consumer : consumers) {
         try {


### PR DESCRIPTION
Summary: If a kafka server isn't running but is used in kafka consumer plugin, we need better error messages to diagnose the issue.

Description: If the kafka server isn't running or if the IP address/hostname is not valid, KafkaException is thrown with an inner ConfigException with the error message `No resolvable bootstrap urls given in bootstrap.servers`.

New pipeline logs after code changes:
```
2021-09-16 15:24:50,552 - ERROR [spark-submitter-DataStreamsSparkStreaming-e3deaa64-173c-11ec-b313-0000009501e8:i.c.p.s.KafkaStreamingSourceUtil@146] 
- Exception occurred while trying to read from kafka topic: Failed to construct kafka consumer
2021-09-16 15:24:50,553 - ERROR [spark-submitter-DataStreamsSparkStreaming-e3deaa64-173c-11ec-b313-0000009501e8:i.c.p.s.KafkaStreamingSourceUtil@147] 
- Please verify that the hostname/IPAddress of the kafka server is correct and that it is running.
2021-09-16 15:24:50,557 - WARN  [spark-submitter-DataStreamsSparkStreaming-e3deaa64-173c-11ec-b313-0000009501e8:o.a.s.s.StreamingContext@66] 
- StreamingContext has not been started yet
2021-09-16 15:24:50,785 - DEBUG [spark-submitter-DataStreamsSparkStreaming-e3deaa64-173c-11ec-b313-0000009501e8:i.c.c.a.r.s.SparkRuntimeEnv$@347] 
- Shutting down Server and ThreadPool used by Spark org.apache.spark.SparkContext@521ddafd
2021-09-16 15:24:50,791 - INFO  [SparkDriverHttpService STOPPING:i.c.h.NettyHttpService@258] 
- Stopping HTTP Service DataStreamsSparkStreaming-http-service
2021-09-16 15:24:50,804 - DEBUG [SparkDriverHttpService STOPPING:i.c.h.NettyHttpService@276] 
- Stopped HTTP Service DataStreamsSparkStreaming-http-service on address localhost/127.0.0.1:53505
2021-09-16 15:24:50,808 - INFO  [SparkRunnerDataStreamsSparkStreaming:i.c.c.d.DataStreamsSparkLauncher@153] - Pipeline 'kafka_test' failed
2021-09-16 15:24:50,809 - DEBUG [SparkRunnerDataStreamsSparkStreaming:i.c.c.a.r.s.SparkRuntimeService@901] - Running Spark shutdown hook org.apache.spark.util.SparkShutdownHookManager$$anon$2@79aa051a
2021-09-16 15:24:50,824 - DEBUG [SparkRunnerDataStreamsSparkStreaming:i.c.c.a.r.s.SparkRuntimeService@376] 
- Spark program completed: SparkRuntimeContext{id=program:default.kafka_test.-SNAPSHOT.spark.DataStreamsSparkStreaming, runId=e3deaa64-173c-11ec-b313-0000009501e8}
2021-09-16 15:24:50,864 - ERROR [SparkRunnerDataStreamsSparkStreaming:i.c.c.i.a.r.ProgramControllerServiceAdapter@92] 
- Spark Program 'DataStreamsSparkStreaming' failed.
java.util.concurrent.ExecutionException: java.lang.RuntimeException: org.apache.kafka.common.KafkaException: Failed to construct kafka consumer
	at com.google.common.util.concurrent.AbstractFuture$Sync.getValue(AbstractFuture.java:294) ~[com.google.guava.guava-13.0.1.jar:na]
	at com.google.common.util.concurrent.AbstractFuture$Sync.get(AbstractFuture.java:281) ~[com.google.guava.guava-13.0.1.jar:na]
	at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:116) ~[com.google.guava.guava-13.0.1.jar:na]
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.run(SparkRuntimeService.java:346) ~[io.cdap.cdap.cdap-spark-core2_2.11-6.6.0-SNAPSHOT.jar:na]
	at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:52) ~[com.google.guava.guava-13.0.1.jar:na]
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService$5$1.run(SparkRuntimeService.java:404) [io.cdap.cdap.cdap-spark-core2_2.11-6.6.0-SNAPSHOT.jar:na]
	at java.lang.Thread.run(Thread.java:748) [na:1.8.0_221]
Caused by: java.lang.RuntimeException: org.apache.kafka.common.KafkaException: Failed to construct kafka consumer
	at io.cdap.cdap.datastreams.SparkStreamingPipelineDriver.lambda$run$2243f9e4$1(SparkStreamingPipelineDriver.java:236) ~[na:na]
	at org.apache.spark.streaming.api.java.JavaStreamingContext$$anonfun$8.apply(JavaStreamingContext.scala:649) ~[na:na]
	at org.apache.spark.streaming.api.java.JavaStreamingContext$$anonfun$8.apply(JavaStreamingContext.scala:648) ~[na:na]
	at scala.Option.getOrElse(Option.scala:121) ~[na:na]
	at org.apache.spark.streaming.StreamingContext$.getOrCreate(StreamingContext.scala:826) ~[na:na]
	at org.apache.spark.streaming.api.java.JavaStreamingContext$.getOrCreate(JavaStreamingContext.scala:648) ~[na:na]
	at org.apache.spark.streaming.api.java.JavaStreamingContext.getOrCreate(JavaStreamingContext.scala) ~[na:na]
	at io.cdap.cdap.datastreams.SparkStreamingPipelineDriver.run(SparkStreamingPipelineDriver.java:246) ~[na:na]
	at io.cdap.cdap.datastreams.SparkStreamingPipelineDriver.run(SparkStreamingPipelineDriver.java:171) ~[na:na]
	at io.cdap.cdap.app.runtime.spark.SparkMainWrapper$.main(SparkMainWrapper.scala:87) ~[na:na]
	at io.cdap.cdap.app.runtime.spark.SparkMainWrapper.main(SparkMainWrapper.scala) ~[na:na]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_221]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_221]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_221]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_221]
	at org.apache.spark.deploy.SparkSubmit$.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:744) ~[na:na]
	at org.apache.spark.deploy.SparkSubmit$.doRunMain$1(SparkSubmit.scala:187) ~[na:na]
	at org.apache.spark.deploy.SparkSubmit$.submit(SparkSubmit.scala:212) ~[na:na]
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:126) ~[na:na]
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala) ~[na:na]
	at io.cdap.cdap.app.runtime.spark.submit.AbstractSparkSubmitter.submit(AbstractSparkSubmitter.java:170) ~[na:na]
	at io.cdap.cdap.app.runtime.spark.submit.AbstractSparkSubmitter.access$000(AbstractSparkSubmitter.java:54) ~[na:na]
	at io.cdap.cdap.app.runtime.spark.submit.AbstractSparkSubmitter$4.run(AbstractSparkSubmitter.java:109) ~[na:na]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[na:1.8.0_221]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[na:1.8.0_221]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[na:1.8.0_221]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[na:1.8.0_221]
	... 1 common frames omitted
Caused by: org.apache.kafka.common.KafkaException: Failed to construct kafka consumer
	at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:717) ~[na:na]
	at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:597) ~[na:na]
	at io.cdap.plugin.source.KafkaStreamingSourceUtil.getStructuredRecordJavaDStream(KafkaStreamingSourceUtil.java:105) ~[na:na]
	at io.cdap.plugin.source.KafkaStreamingSource.getStream(KafkaStreamingSource.java:87) ~[na:na]
	at io.cdap.cdap.etl.spark.plugin.WrappedStreamingSource$2.call(WrappedStreamingSource.java:76) ~[na:na]
	at io.cdap.cdap.etl.spark.plugin.WrappedStreamingSource$2.call(WrappedStreamingSource.java:73) ~[na:na]
	at io.cdap.cdap.etl.common.plugin.Caller$1.call(Caller.java:30) ~[na:na]
	at io.cdap.cdap.etl.spark.plugin.WrappedStreamingSource.getStream(WrappedStreamingSource.java:73) ~[na:na]
	at io.cdap.cdap.datastreams.SparkStreamingPipelineRunner.getSource(SparkStreamingPipelineRunner.java:110) ~[na:na]
	at io.cdap.cdap.etl.spark.SparkPipelineRunner.runPipeline(SparkPipelineRunner.java:258) ~[na:na]
	at io.cdap.cdap.datastreams.SparkStreamingPipelineDriver.lambda$run$2243f9e4$1(SparkStreamingPipelineDriver.java:232) ~[na:na]
	... 27 common frames omitted
Caused by: org.apache.kafka.common.config.ConfigException: No resolvable bootstrap urls given in bootstrap.servers
	at org.apache.kafka.clients.ClientUtils.parseAndValidateAddresses(ClientUtils.java:60) ~[na:na]
	at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:654) ~[na:na]
	... 37 common frames omitted

```