### PR TITLE
CDAP-19560 - Save offset in state store for atleast once processing.

### DIFF
--- a/kafka-plugins-client/pom.xml
+++ b/kafka-plugins-client/pom.xml
@@ -204,6 +204,33 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>3.3.1</version>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <phase>compile</phase>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <phase>test-compile</phase>
+          </execution>
+          <execution>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <version>3.5.1</version>
@@ -231,8 +258,8 @@
         <version>1.1.0</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[6.7.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[6.7.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[6.8.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[6.8.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>

--- a/kafka-plugins-client/src/main/java/io/cdap/plugin/source/KafkaStreamingSource.java
+++ b/kafka-plugins-client/src/main/java/io/cdap/plugin/source/KafkaStreamingSource.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.source;
 
+import com.google.gson.Gson;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -27,11 +28,29 @@ import io.cdap.cdap.etl.api.StageConfigurer;
 import io.cdap.cdap.etl.api.streaming.StreamingContext;
 import io.cdap.cdap.etl.api.streaming.StreamingSource;
 import io.cdap.cdap.etl.api.streaming.StreamingSourceContext;
+import io.cdap.cdap.etl.api.streaming.StreamingStateHandler;
+import io.cdap.plugin.batch.source.KafkaPartitionOffsets;
 import io.cdap.plugin.common.LineageRecorder;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.spark.api.java.function.VoidFunction;
 import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaInputDStream;
+import org.apache.spark.streaming.kafka010.OffsetRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -40,7 +59,11 @@ import java.util.stream.Collectors;
 @Plugin(type = StreamingSource.PLUGIN_TYPE)
 @Name("Kafka")
 @Description("Kafka streaming source.")
-public class KafkaStreamingSource extends ReferenceStreamingSource<StructuredRecord> {
+public class KafkaStreamingSource extends ReferenceStreamingSource<StructuredRecord> implements StreamingStateHandler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaStreamingSource.class);
+  private static final Gson gson = new Gson();
+
   private final KafkaConfig conf;
 
   public KafkaStreamingSource(KafkaConfig conf) {
@@ -84,6 +107,69 @@ public class KafkaStreamingSource extends ReferenceStreamingSource<StructuredRec
     conf.getMessageSchema(collector);
     collector.getOrThrowException();
 
-    return KafkaStreamingSourceUtil.getStructuredRecordJavaDStream(context, conf, collector);
+    JavaInputDStream<ConsumerRecord<byte[], byte[]>> recordJavaDStream =
+      KafkaStreamingSourceUtil.getConsumerRecordJavaDStream(context, conf, collector, getStateSupplier(context));
+    if (!context.isStateStoreEnabled()) {
+      // Return the serializable Dstream in case checkpointing is enabled.
+      return KafkaStreamingSourceUtil.getStructuredRecordJavaDStream(conf, recordJavaDStream);
+    }
+
+    // Use the DStream that is state aware
+    KafkaDStream kafkaDStream = new KafkaDStream(context.getSparkStreamingContext().ssc(),
+                                                 recordJavaDStream.inputDStream(),
+                                                 KafkaStreamingSourceUtil.getRecordTransformFunction(conf),
+                                                 getStateConsumer(context));
+    return kafkaDStream.convertToJavaDStream();
+  }
+
+  private VoidFunction<OffsetRange[]> getStateConsumer(StreamingContext context) {
+    return offsetRanges -> {
+      try {
+        saveState(context, offsetRanges);
+      } catch (IOException e) {
+        LOG.warn("Exception in saving state.", e);
+      }
+    };
+  }
+
+  private void saveState(StreamingContext context, OffsetRange[] offsetRanges) throws IOException {
+    if (offsetRanges.length > 0) {
+      Map<Integer, Long> partitionOffsetMap = Arrays.stream(offsetRanges)
+        .collect(Collectors.toMap(OffsetRange::partition, OffsetRange::untilOffset));
+      byte[] state = gson.toJson(new KafkaPartitionOffsets(partitionOffsetMap)).getBytes(StandardCharsets.UTF_8);
+      context.saveState(conf.getTopic(), state);
+    }
+  }
+
+  private Supplier<Map<TopicPartition, Long>> getStateSupplier(StreamingContext context) {
+    return () -> {
+      try {
+        return getSavedState(context);
+      } catch (IOException e) {
+        throw new RuntimeException("Exception in fetching state.", e);
+      }
+    };
+  }
+
+  private Map<TopicPartition, Long> getSavedState(StreamingContext context) throws IOException {
+    //State store is not enabled, do not read state
+    if (!context.isStateStoreEnabled()) {
+      return Collections.emptyMap();
+    }
+
+    //If state is not present, use configured offsets or defaults
+    Optional<byte[]> state = context.getState(conf.getTopic());
+    if (!state.isPresent()) {
+      return Collections.emptyMap();
+    }
+
+    byte[] bytes = state.get();
+    try (Reader reader = new InputStreamReader(new ByteArrayInputStream(bytes), StandardCharsets.UTF_8)) {
+      KafkaPartitionOffsets partitionOffsets = gson.fromJson(reader, KafkaPartitionOffsets.class);
+      return partitionOffsets.getPartitionOffsets().entrySet()
+        .stream()
+        .collect(Collectors.toMap(partitionOffset -> new TopicPartition(conf.getTopic(), partitionOffset.getKey()),
+                                  Map.Entry::getValue));
+    }
   }
 }

--- a/kafka-plugins-client/src/main/scala/io/cdap/plugin/source/KafkaDStream.scala
+++ b/kafka-plugins-client/src/main/scala/io/cdap/plugin/source/KafkaDStream.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.source
+
+import io.cdap.cdap.api.data.format.StructuredRecord
+import io.cdap.cdap.etl.api.streaming.StreamingEventHandler
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.spark.api.java.function.{Function2, VoidFunction}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.streaming.api.java.JavaDStream
+import org.apache.spark.streaming.{Duration, StreamingContext, Time}
+import org.apache.spark.streaming.dstream.{DStream, InputDStream}
+import org.apache.spark.streaming.kafka010.{HasOffsetRanges, OffsetRange}
+
+import java.util.function.Consumer
+
+/**
+ * DStream that implements {@link StreamingEventHandler} .
+ * This DStream will keep the Kafka offsets for each batch RDD before applying the _transformFunction.
+ * On calling onBatchCompleted, the _stateConsumer will be provided with these offsets.
+ *
+ * @param _ssc           Spark streaming context
+ * @param _kafkaDStream  DStream created through KafkaUtil.createDirectStream
+ * @param _kafkaConf     Config object for Kafka Streaming Source
+ * @param _stateConsumer Consumer function for the state produced
+ */
+class KafkaDStream(_ssc: StreamingContext,
+                   _kafkaDStream: InputDStream[ConsumerRecord[Array[Byte], Array[Byte]]],
+                   _transformFunction: Function2[ConsumerRecord[Array[Byte], Array[Byte]], Time, StructuredRecord],
+                   _stateConsumer: VoidFunction[Array[OffsetRange]])
+  extends DStream[StructuredRecord](_ssc) with StreamingEventHandler {
+
+  // For keeping the offsets in each batch
+  private var offsetRanges: Array[OffsetRange] = Array[OffsetRange]()
+
+  override def slideDuration: Duration = _kafkaDStream.slideDuration
+
+  override def dependencies: List[DStream[_]] = List(_kafkaDStream)
+
+  override def compute(validTime: Time): Option[RDD[StructuredRecord]] = {
+    val rddOption = _kafkaDStream.compute(validTime)
+    val transformFn = _transformFunction;
+    // If there is a RDD produced, cache the offsetRanges for the batch and then transform to RDD[StructuredRecord]
+    rddOption.map(rdd => {
+      offsetRanges = rdd.asInstanceOf[HasOffsetRanges].offsetRanges
+      rdd.map(record => transformFn.call(record, validTime))
+    })
+  }
+
+  override def onBatchCompleted(context: io.cdap.cdap.etl.api.streaming.StreamingContext): Unit = {
+    _stateConsumer.call(offsetRanges)
+  }
+
+  /**
+   * Convert this to a {@link JavaDStream}
+   *
+   * @return JavaDStream
+   */
+  def convertToJavaDStream(): JavaDStream[StructuredRecord] = {
+    JavaDStream.fromDStream(this)
+  }
+}

--- a/kafka-plugins-client/src/test/java/io/cdap/plugin/KafkaStreamingSourceBegginingOffsetTest.java
+++ b/kafka-plugins-client/src/test/java/io/cdap/plugin/KafkaStreamingSourceBegginingOffsetTest.java
@@ -35,7 +35,6 @@ import io.cdap.cdap.etl.mock.test.HydratorTestBase;
 import io.cdap.cdap.etl.proto.v2.DataStreamsConfig;
 import io.cdap.cdap.etl.proto.v2.ETLPlugin;
 import io.cdap.cdap.etl.proto.v2.ETLStage;
-import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ArtifactId;
@@ -47,7 +46,6 @@ import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.plugin.common.http.HTTPPollConfig;
 import io.cdap.plugin.source.KafkaStreamingSource;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -67,15 +65,18 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static io.cdap.plugin.source.KafkaConfig.OFFSET_START_FROM_BEGINNING;
-import static io.cdap.plugin.source.KafkaConfig.OFFSET_START_FROM_LAST_OFFSET;
 
 /**
  * Tests for Spark plugins.
  */
 public class KafkaStreamingSourceBegginingOffsetTest extends HydratorTestBase {
 
+  // Explicitly turn off state tracking to ensure checkpointing is on.
+  // This test needs a fix to work with checkpointing disabled. See PLUGIN-1414
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG =
+    new TestConfiguration("explore.enabled", false,
+                          "feature.streaming.pipeline.native.state.tracking.enabled", "false");
 
   private static final ArtifactId DATAPIPELINE_ARTIFACT_ID =
     NamespaceId.DEFAULT.artifact("data-pipeline", "4.3.2");

--- a/kafka-plugins-client/src/test/java/io/cdap/plugin/KafkaStreamingSourceSpecificOffsetTest.java
+++ b/kafka-plugins-client/src/test/java/io/cdap/plugin/KafkaStreamingSourceSpecificOffsetTest.java
@@ -35,7 +35,6 @@ import io.cdap.cdap.etl.mock.test.HydratorTestBase;
 import io.cdap.cdap.etl.proto.v2.DataStreamsConfig;
 import io.cdap.cdap.etl.proto.v2.ETLPlugin;
 import io.cdap.cdap.etl.proto.v2.ETLStage;
-import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ArtifactId;
@@ -47,7 +46,6 @@ import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.plugin.common.http.HTTPPollConfig;
 import io.cdap.plugin.source.KafkaStreamingSource;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -66,7 +64,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static io.cdap.plugin.source.KafkaConfig.OFFSET_START_FROM_LAST_OFFSET;
 import static io.cdap.plugin.source.KafkaConfig.OFFSET_START_FROM_SPECIFIC_OFFSET;
 
 /**
@@ -74,8 +71,12 @@ import static io.cdap.plugin.source.KafkaConfig.OFFSET_START_FROM_SPECIFIC_OFFSE
  */
 public class KafkaStreamingSourceSpecificOffsetTest extends HydratorTestBase {
 
+  // Explicitly turn off state tracking to ensure checkpointing is on.
+  // This test needs a fix to work with checkpointing disabled. See PLUGIN-1414
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG =
+    new TestConfiguration("explore.enabled", false,
+                          "feature.streaming.pipeline.native.state.tracking.enabled", "false");
 
   private static final ArtifactId DATAPIPELINE_ARTIFACT_ID =
     NamespaceId.DEFAULT.artifact("data-pipeline", "4.3.2");

--- a/kafka-plugins-client/src/test/java/io/cdap/plugin/KafkaStreamingSourceStateStoreTest.java
+++ b/kafka-plugins-client/src/test/java/io/cdap/plugin/KafkaStreamingSourceStateStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,8 @@ package io.cdap.plugin;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.gson.Gson;
+import io.cdap.cdap.api.app.AppStateStore;
 import io.cdap.cdap.api.artifact.ArtifactRange;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.api.artifact.ArtifactVersion;
@@ -26,7 +28,6 @@ import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.table.Table;
 import io.cdap.cdap.common.utils.Networks;
 import io.cdap.cdap.common.utils.Tasks;
-import io.cdap.cdap.datapipeline.DataPipelineApp;
 import io.cdap.cdap.datastreams.DataStreamsApp;
 import io.cdap.cdap.datastreams.DataStreamsSparkLauncher;
 import io.cdap.cdap.etl.api.streaming.StreamingSource;
@@ -43,7 +44,9 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.DataSetManager;
 import io.cdap.cdap.test.SparkManager;
+import io.cdap.cdap.test.TestBase;
 import io.cdap.cdap.test.TestConfiguration;
+import io.cdap.plugin.batch.source.KafkaPartitionOffsets;
 import io.cdap.plugin.common.http.HTTPPollConfig;
 import io.cdap.plugin.source.KafkaStreamingSource;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -54,39 +57,45 @@ import org.apache.spark.streaming.kafka010.KafkaUtils;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static io.cdap.plugin.source.KafkaConfig.OFFSET_START_FROM_LAST_OFFSET;
-
 /**
- * Tests for Spark plugins.
+ * Tests for Kafka streaming source with state store
  */
-public class KafkaStreamingSourceLastOffsetTest extends HydratorTestBase {
+public class KafkaStreamingSourceStateStoreTest extends HydratorTestBase {
 
-  // Explicitly turn off state tracking to ensure checkpointing is on.
-  // This test needs a fix to work with checkpointing disabled. See PLUGIN-1414
+  // Turn on state tracking.
   @ClassRule
   public static final TestConfiguration CONFIG =
     new TestConfiguration("explore.enabled", false,
-                          "feature.streaming.pipeline.native.state.tracking.enabled", "false");
+                          "feature.streaming.pipeline.native.state.tracking.enabled", "true");
+  private static final Gson GSON = new Gson();
 
-  private static final ArtifactId DATAPIPELINE_ARTIFACT_ID =
-    NamespaceId.DEFAULT.artifact("data-pipeline", "4.3.2");
   private static final ArtifactId DATASTREAMS_ARTIFACT_ID =
-    NamespaceId.DEFAULT.artifact("data-streams", "4.3.2");
+    NamespaceId.DEFAULT.artifact("data-streams", "6.8.0");
   private static final ArtifactSummary DATASTREAMS_ARTIFACT =
-    new ArtifactSummary("data-streams", "4.3.2");
+    new ArtifactSummary("data-streams", "6.8.0");
   private static final int ZOOKEEPER_TICK_TIME = 1000;
   private static final int ZOOKEEPER_MAX_CONNECTIONS = 100;
+  private static final String SOURCE_REFERENCE_NAME = "kafkaPurchases";
+  private static final String SRC_STAGE_NAME = "source";
+  private static final String TOPIC_NAME = "users";
 
   private static ZooKeeperServer zkServer;
   private static ServerCnxnFactory standaloneServerFactory;
@@ -99,21 +108,15 @@ public class KafkaStreamingSourceLastOffsetTest extends HydratorTestBase {
 
   @BeforeClass
   public static void setupTest() throws Exception {
-    // add the artifact for data pipeline app
-    setupBatchArtifacts(DATAPIPELINE_ARTIFACT_ID, DataPipelineApp.class);
-
     setupStreamingArtifacts(DATASTREAMS_ARTIFACT_ID, DataStreamsApp.class);
 
-    // add artifact for spark plugins
+    // add artifact for kafka plugins
     Set<ArtifactRange> parents = ImmutableSet.of(
-      new ArtifactRange(NamespaceId.DEFAULT.getNamespace(), DATAPIPELINE_ARTIFACT_ID.getArtifact(),
-                        new ArtifactVersion(DATAPIPELINE_ARTIFACT_ID.getVersion()), true,
-                        new ArtifactVersion(DATAPIPELINE_ARTIFACT_ID.getVersion()), true),
       new ArtifactRange(NamespaceId.DEFAULT.getNamespace(), DATASTREAMS_ARTIFACT_ID.getArtifact(),
                         new ArtifactVersion(DATASTREAMS_ARTIFACT_ID.getVersion()), true,
                         new ArtifactVersion(DATASTREAMS_ARTIFACT_ID.getVersion()), true)
     );
-    addPluginArtifact(NamespaceId.DEFAULT.artifact("spark-plugins", "1.0.0"), parents,
+    addPluginArtifact(NamespaceId.DEFAULT.artifact("kafka-plugins", "1.0.0"), parents,
                       KafkaStreamingSource.class, KafkaUtils.class, Deserializer.class, ByteArrayDeserializer.class,
                       TopicPartition.class, HTTPPollConfig.class);
 
@@ -152,7 +155,7 @@ public class KafkaStreamingSourceLastOffsetTest extends HydratorTestBase {
   }
 
   @Test
-  public void testKafkaStreamingSourceFromLastOffset() throws Exception {
+  public void testKafkaStreamingSource() throws Exception {
     Schema schema = Schema.recordOf(
       "user",
       Schema.Field.of("id", Schema.of(Schema.Type.LONG)),
@@ -160,19 +163,21 @@ public class KafkaStreamingSourceLastOffsetTest extends HydratorTestBase {
       Schema.Field.of("last", Schema.of(Schema.Type.STRING)));
 
     Map<String, String> properties = new HashMap<>();
-    properties.put("referenceName", "kafkaPurchasesLastOffsetTest");
+    properties.put("referenceName", SOURCE_REFERENCE_NAME);
     properties.put("brokers", "localhost:" + kafkaPort);
-    properties.put("topic", "usersWithLastOffsetTest");
-    properties.put("initialOffset", OFFSET_START_FROM_LAST_OFFSET);
+    properties.put("topic", TOPIC_NAME);
+    properties.put("defaultInitialOffset", "-2");
     properties.put("format", "csv");
     properties.put("schema", schema.toString());
 
-    ETLStage source = new ETLStage("source", new ETLPlugin("Kafka", StreamingSource.PLUGIN_TYPE, properties, null));
+
+    ETLStage source = new ETLStage(SRC_STAGE_NAME,
+                                   new ETLPlugin("Kafka", StreamingSource.PLUGIN_TYPE, properties, null));
 
     DataStreamsConfig etlConfig = DataStreamsConfig.builder()
       .addStage(source)
-      .addStage(new ETLStage("sink", MockSink.getPlugin("kafkaOutputLastOffsetTest")))
-      .addConnection("source", "sink")
+      .addStage(new ETLStage("sink", MockSink.getPlugin("kafkaOutput")))
+      .addConnection(SRC_STAGE_NAME, "sink")
       .setBatchInterval("1s")
       .setStopGracefully(true)
       .build();
@@ -181,30 +186,28 @@ public class KafkaStreamingSourceLastOffsetTest extends HydratorTestBase {
     ApplicationId appId = NamespaceId.DEFAULT.app("KafkaSourceApp");
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
-    //Initialize topic
-    Map<String, String> messages;
-    messages = new HashMap<>();
-    messages.put("z", "0,clint,eastwood");
-    KafkaTestCommon.sendKafkaMessage(kafkaProducer, "usersWithLastOffsetTest", messages);
-
-    SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
-    sparkManager.start();
-    sparkManager.waitForStatus(true, 10, 1);
-
-    // for this test we have to wait for pipeline to be in running state before sending data
-    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 20, TimeUnit.SECONDS);
-    final DataSetManager<Table> outputManager = getDataset("kafkaOutputLastOffsetTest");
-
-    // Write additional messages into topic
-    TimeUnit.SECONDS.sleep(10);
-    messages = new HashMap<>();
+    // write some messages to kafka
+    Map<String, String> messages = new HashMap<>();
     messages.put("a", "1,samuel,jackson");
     messages.put("b", "2,dwayne,johnson");
     messages.put("c", "3,christopher,walken");
-    KafkaTestCommon.sendKafkaMessage(kafkaProducer, "usersWithLastOffsetTest", messages);
+    KafkaTestCommon.sendKafkaMessage(kafkaProducer, TOPIC_NAME, messages);
 
+    // Save an entry for offset 1 (second in the data) in state store with reference name.
+    AppStateStore appStateStore = TestBase.getAppStateStore(appId.getNamespace(), appId.getApplication());
+    appStateStore.saveState(SRC_STAGE_NAME + "." + TOPIC_NAME,
+                            GSON.toJson(new KafkaPartitionOffsets(Collections.singletonMap(0, 1L)))
+                              .getBytes(StandardCharsets.UTF_8));
+
+    // Launch the program and wait for results
+    SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
+    sparkManager.start();
+    sparkManager.waitForRun(ProgramRunStatus.RUNNING, 2, TimeUnit.MINUTES);
+
+    final DataSetManager<Table> outputManager = getDataset("kafkaOutput");
+    // Should start reading from offset 1, so should skip the message at offset 0.
     Tasks.waitFor(
-      ImmutableMap.of(1L, "samuel jackson", 2L, "dwayne johnson", 3L, "christopher walken"),
+      ImmutableMap.of(2L, "dwayne johnson", 3L, "christopher walken"),
       () -> {
         outputManager.flush();
         Map<Long, String> actual = new HashMap<>();
@@ -214,7 +217,17 @@ public class KafkaStreamingSourceLastOffsetTest extends HydratorTestBase {
         return actual;
       }, 2, TimeUnit.MINUTES);
 
+    // Verify that state is saved with the next offset to start from.
+    Optional<byte[]> savedState = appStateStore.getState(SRC_STAGE_NAME + "." + TOPIC_NAME);
+    Assert.assertTrue(savedState.isPresent());
+    try (Reader reader = new InputStreamReader(new ByteArrayInputStream(savedState.get()), StandardCharsets.UTF_8)) {
+      KafkaPartitionOffsets partitionOffsets = GSON.fromJson(reader, KafkaPartitionOffsets.class);
+      Long savedOffset = partitionOffsets.getPartitionOffsets().get(0);
+      Assert.assertEquals(3L, savedOffset.longValue());
+    }
+
+    // stop the run
     sparkManager.stop();
-    sparkManager.waitForStatus(false, 10, 1);
+    sparkManager.waitForRun(ProgramRunStatus.KILLED, 2, TimeUnit.MINUTES);
   }
 }

--- a/kafka-plugins-client/src/test/java/io/cdap/plugin/KafkaStreamingSourceTest.java
+++ b/kafka-plugins-client/src/test/java/io/cdap/plugin/KafkaStreamingSourceTest.java
@@ -35,7 +35,6 @@ import io.cdap.cdap.etl.mock.test.HydratorTestBase;
 import io.cdap.cdap.etl.proto.v2.DataStreamsConfig;
 import io.cdap.cdap.etl.proto.v2.ETLPlugin;
 import io.cdap.cdap.etl.proto.v2.ETLStage;
-import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ArtifactId;
@@ -47,7 +46,6 @@ import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.plugin.common.http.HTTPPollConfig;
 import io.cdap.plugin.source.KafkaStreamingSource;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -63,21 +61,20 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
-import static io.cdap.plugin.source.KafkaConfig.OFFSET_START_FROM_BEGINNING;
-import static io.cdap.plugin.source.KafkaConfig.OFFSET_START_FROM_LAST_OFFSET;
-import static io.cdap.plugin.source.KafkaConfig.OFFSET_START_FROM_SPECIFIC_OFFSET;
 
 /**
  * Tests for Spark plugins.
  */
 public class KafkaStreamingSourceTest extends HydratorTestBase {
 
+  // Explicitly turn off state tracking to ensure checkpointing is on.
+  // This test needs a fix to work with checkpointing disabled. See PLUGIN-1414
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+  public static final TestConfiguration CONFIG =
+    new TestConfiguration("explore.enabled", false,
+                          "feature.streaming.pipeline.native.state.tracking.enabled", "false");
 
   private static final ArtifactId DATAPIPELINE_ARTIFACT_ID =
     NamespaceId.DEFAULT.artifact("data-pipeline", "4.3.2");

--- a/kafka-plugins-common/src/main/java/io/cdap/plugin/batch/source/KafkaPartitionOffsets.java
+++ b/kafka-plugins-common/src/main/java/io/cdap/plugin/batch/source/KafkaPartitionOffsets.java
@@ -54,6 +54,10 @@ public class KafkaPartitionOffsets {
     return partitionOffsets.getOrDefault(partition, defaultValue);
   }
 
+  public Map<Integer, Long> getPartitionOffsets() {
+    return Collections.unmodifiableMap(partitionOffsets);
+  }
+
   /**
    * Loads the {@link KafkaPartitionOffsets} from the given input file.
    *


### PR DESCRIPTION
- Introduce a new DStream that keeps the offsets from the raw stream before applying any transformations and provides the ability to save these offsets.
- Streaming source uses new Dstream when state store is enabled and uses the default one otherwise. Checkpointing does not work with new Dstream since StreamingContext is not serializable.
- When state store is enabled, offsets are read from the store and if not present, falls back to default behavior
