### PR TITLE
[CDAP-20224] Removed Explore References from `kafka-plugins`

### DIFF
--- a/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/AbstractKafkaBatchSourceTest.java
+++ b/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/AbstractKafkaBatchSourceTest.java
@@ -38,7 +38,6 @@ import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.DataSetManager;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.cdap.test.WorkflowManager;
 import io.cdap.plugin.kafka.batch.source.KafkaBatchConfig;
 import io.cdap.plugin.kafka.batch.source.KafkaPartitionOffsets;
@@ -51,7 +50,6 @@ import org.apache.zookeeper.server.ZooKeeperServer;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.File;
@@ -71,8 +69,6 @@ import java.util.concurrent.TimeUnit;
 public abstract class AbstractKafkaBatchSourceTest extends HydratorTestBase {
 
   private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("data-pipeline", "1.0.0");
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
   private static final int ZOOKEEPER_TICK_TIME = 1000;
   private static final int ZOOKEEPER_MAX_CONNECTIONS = 100;
 

--- a/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/KafkaSinkAndAlertsPublisherTest.java
+++ b/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/KafkaSinkAndAlertsPublisherTest.java
@@ -41,7 +41,6 @@ import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.DataSetManager;
-import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.cdap.test.WorkflowManager;
 import io.cdap.plugin.kafka.alertpublisher.KafkaAlertPublisher;
 import io.cdap.plugin.kafka.sink.KafkaBatchSink;
@@ -55,7 +54,6 @@ import org.apache.zookeeper.server.ZooKeeperServer;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.File;
@@ -75,8 +73,6 @@ import java.util.stream.Collectors;
  */
 public class KafkaSinkAndAlertsPublisherTest extends HydratorTestBase {
   private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("data-pipeline", "1.0.0");
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
 
   private static final Gson GSON = new Gson();
   private static final int ZOOKEEPER_TICK_TIME = 1000;

--- a/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/KafkaStreamingSourceBegginingOffsetTest.java
+++ b/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/KafkaStreamingSourceBegginingOffsetTest.java
@@ -75,8 +75,7 @@ public class KafkaStreamingSourceBegginingOffsetTest extends HydratorTestBase {
   // This test needs a fix to work with checkpointing disabled. See PLUGIN-1414
   @ClassRule
   public static final TestConfiguration CONFIG =
-    new TestConfiguration("explore.enabled", false,
-                          "feature.streaming.pipeline.native.state.tracking.enabled", "false");
+    new TestConfiguration("feature.streaming.pipeline.native.state.tracking.enabled", "false");
 
   private static final ArtifactId DATAPIPELINE_ARTIFACT_ID =
     NamespaceId.DEFAULT.artifact("data-pipeline", "4.3.2");

--- a/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/KafkaStreamingSourceLastOffsetTest.java
+++ b/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/KafkaStreamingSourceLastOffsetTest.java
@@ -75,8 +75,7 @@ public class KafkaStreamingSourceLastOffsetTest extends HydratorTestBase {
   // This test needs a fix to work with checkpointing disabled. See PLUGIN-1414
   @ClassRule
   public static final TestConfiguration CONFIG =
-    new TestConfiguration("explore.enabled", false,
-                          "feature.streaming.pipeline.native.state.tracking.enabled", "false");
+    new TestConfiguration("feature.streaming.pipeline.native.state.tracking.enabled", "false");
 
   private static final ArtifactId DATAPIPELINE_ARTIFACT_ID =
     NamespaceId.DEFAULT.artifact("data-pipeline", "4.3.2");

--- a/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/KafkaStreamingSourceSpecificOffsetTest.java
+++ b/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/KafkaStreamingSourceSpecificOffsetTest.java
@@ -75,8 +75,7 @@ public class KafkaStreamingSourceSpecificOffsetTest extends HydratorTestBase {
   // This test needs a fix to work with checkpointing disabled. See PLUGIN-1414
   @ClassRule
   public static final TestConfiguration CONFIG =
-    new TestConfiguration("explore.enabled", false,
-                          "feature.streaming.pipeline.native.state.tracking.enabled", "false");
+    new TestConfiguration("feature.streaming.pipeline.native.state.tracking.enabled", "false");
 
   private static final ArtifactId DATAPIPELINE_ARTIFACT_ID =
     NamespaceId.DEFAULT.artifact("data-pipeline", "4.3.2");

--- a/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/KafkaStreamingSourceStateStoreFailureTest.java
+++ b/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/KafkaStreamingSourceStateStoreFailureTest.java
@@ -76,8 +76,7 @@ public class KafkaStreamingSourceStateStoreFailureTest extends HydratorTestBase 
   // Turn on state tracking.
   @ClassRule
   public static final TestConfiguration CONFIG =
-    new TestConfiguration("explore.enabled", false,
-                          "feature.streaming.pipeline.native.state.tracking.enabled", "true");
+    new TestConfiguration("feature.streaming.pipeline.native.state.tracking.enabled", "true");
   private static final Gson GSON = new Gson();
 
   private static final ArtifactId DATASTREAMS_ARTIFACT_ID =

--- a/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/KafkaStreamingSourceStateStoreRecoveryTest.java
+++ b/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/KafkaStreamingSourceStateStoreRecoveryTest.java
@@ -85,8 +85,7 @@ public class KafkaStreamingSourceStateStoreRecoveryTest extends HydratorTestBase
   // Turn on state tracking.
   @ClassRule
   public static final TestConfiguration CONFIG =
-    new TestConfiguration("explore.enabled", false,
-                          "feature.streaming.pipeline.native.state.tracking.enabled", "true");
+    new TestConfiguration("feature.streaming.pipeline.native.state.tracking.enabled", "true");
   private static final Gson GSON = new Gson();
 
   private static final ArtifactId DATASTREAMS_ARTIFACT_ID =

--- a/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/KafkaStreamingSourceStateStoreTest.java
+++ b/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/KafkaStreamingSourceStateStoreTest.java
@@ -61,6 +61,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStreamReader;
@@ -81,8 +82,7 @@ public class KafkaStreamingSourceStateStoreTest extends HydratorTestBase {
   // Turn on state tracking.
   @ClassRule
   public static final TestConfiguration CONFIG =
-    new TestConfiguration("explore.enabled", false,
-                          "feature.streaming.pipeline.native.state.tracking.enabled", "true");
+    new TestConfiguration("feature.streaming.pipeline.native.state.tracking.enabled", "true");
   private static final Gson GSON = new Gson();
 
   private static final ArtifactId DATASTREAMS_ARTIFACT_ID =

--- a/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/KafkaStreamingSourceTest.java
+++ b/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/KafkaStreamingSourceTest.java
@@ -73,8 +73,7 @@ public class KafkaStreamingSourceTest extends HydratorTestBase {
   // This test needs a fix to work with checkpointing disabled. See PLUGIN-1414
   @ClassRule
   public static final TestConfiguration CONFIG =
-    new TestConfiguration("explore.enabled", false,
-                          "feature.streaming.pipeline.native.state.tracking.enabled", "false");
+    new TestConfiguration("feature.streaming.pipeline.native.state.tracking.enabled", "false");
 
   private static final ArtifactId DATAPIPELINE_ARTIFACT_ID =
     NamespaceId.DEFAULT.artifact("data-pipeline", "4.3.2");


### PR DESCRIPTION
- As part of cdapio/cdap/pull/14802, the module `cdap-explore` and its references and occurrences are removed from CDAP repository.
- Similar references in `kafka-plugins` need to be removed.
[JIRA](https://cdap.atlassian.net/browse/CDAP-20224)