### PR TITLE
[CDAP-20238] Remove Spark2 references and update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <docs.dir>docs</docs.dir>
     <kafka.version>2.6.0</kafka.version>
     <hadoop.version>2.6.0</hadoop.version>
-    <netty.version>4.1.16.Final</netty.version>
+    <netty.version>4.1.75.Final</netty.version>
     <netty-http.version>1.3.0</netty-http.version>
     <avro.version>1.8.2</avro.version>
     <main.basedir>${project.basedir}</main.basedir>
@@ -98,6 +98,12 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-unit-test</artifactId>
+      <version>${cdap.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-etl-api</artifactId>
@@ -136,16 +142,6 @@
       <artifactId>hydrator-test</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.kafka</groupId>
-          <artifactId>kafka_2.10</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-core_2.10</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.cdap.plugin</groupId>


### PR DESCRIPTION
As part of cdapio/cdap/pull/14797, the spark2 modules and references have been removed. Similar references in this repo need to be done and subsequent dependencies need to be updated.