### PR TITLE
CDAP-19731 - Validate offsets and give informative error message.

### DIFF
--- a/kafka-plugins-client/src/main/java/io/cdap/plugin/kafka/common/KafkaHelpers.java
+++ b/kafka-plugins-client/src/main/java/io/cdap/plugin/kafka/common/KafkaHelpers.java
@@ -23,8 +23,9 @@ import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -49,7 +50,10 @@ public final class KafkaHelpers {
    * @return Mapping of topic-partiton to its latest offset
    */
   public static <K, V> Map<TopicPartition, Long> getLatestOffsets(Consumer<K, V> consumer,
-                                                                  List<TopicPartition> topicAndPartitions) {
+                                                                  Collection<TopicPartition> topicAndPartitions) {
+    if (topicAndPartitions.isEmpty()) {
+      return Collections.emptyMap();
+    }
     consumer.assign(topicAndPartitions);
     consumer.seekToEnd(topicAndPartitions);
 
@@ -69,7 +73,10 @@ public final class KafkaHelpers {
    * @return Mapping of topic-partiton to its earliest offset
    */
   public static <K, V> Map<TopicPartition, Long> getEarliestOffsets(Consumer<K, V> consumer,
-                                                                    List<TopicPartition> topicAndPartitions) {
+                                                                    Collection<TopicPartition> topicAndPartitions) {
+    if (topicAndPartitions.isEmpty()) {
+      return Collections.emptyMap();
+    }
     consumer.assign(topicAndPartitions);
     consumer.seekToBeginning(topicAndPartitions);
 

--- a/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/source/KafkaStreamingSourceUtilTest.java
+++ b/kafka-plugins-client/src/test/java/io/cdap/plugin/kafka/source/KafkaStreamingSourceUtilTest.java
@@ -1,0 +1,45 @@
+package io.cdap.plugin.kafka.source;
+
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tests for KafkaStreamingSourceUtil
+ */
+public class KafkaStreamingSourceUtilTest {
+
+  @Test
+  public void testValidateSavedPartitionsValid() {
+    Map<TopicPartition, Long> savedPartitions = new HashMap<>();
+    TopicPartition partition1 = new TopicPartition("test-topic", 0);
+    TopicPartition partition2 = new TopicPartition("test-topic", 1);
+    savedPartitions.put(partition1, 100L);
+    savedPartitions.put(partition2, 102L);
+    Map<TopicPartition, Long> earliestOffsets = new HashMap<>();
+    earliestOffsets.put(partition1, 0L);
+    earliestOffsets.put(partition2, 0L);
+    Map<TopicPartition, Long> latestOffsets = new HashMap<>();
+    latestOffsets.put(partition1, 202L);
+    latestOffsets.put(partition2, 200L);
+    KafkaStreamingSourceUtil.validateSavedPartitions(savedPartitions, earliestOffsets, latestOffsets);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidateSavedPartitionsInvalid() {
+    Map<TopicPartition, Long> savedPartitions = new HashMap<>();
+    TopicPartition partition1 = new TopicPartition("test-topic", 0);
+    TopicPartition partition2 = new TopicPartition("test-topic", 1);
+    savedPartitions.put(partition1, 100L);
+    savedPartitions.put(partition2, 102L);
+    Map<TopicPartition, Long> earliestOffsets = new HashMap<>();
+    earliestOffsets.put(partition1, 0L);
+    earliestOffsets.put(partition2, 0L);
+    Map<TopicPartition, Long> latestOffsets = new HashMap<>();
+    latestOffsets.put(partition1, 10L);
+    latestOffsets.put(partition2, 0L);
+    KafkaStreamingSourceUtil.validateSavedPartitions(savedPartitions, earliestOffsets, latestOffsets);
+  }
+}


### PR DESCRIPTION
CDAP-19731: With state management, Kafka offsets are saved for each micro batch. If the pipeline is restarted and the saved offsets are not valid (due to retention expiry or topic recreation), the error message is not informative - "java.lang.IllegalArgumentException: requirement failed: numRecords must not be negative" thrown from Scala code for Dstream. 

This change will validate the saved offsets against the starting and ending offsets for each partition and provides a more informative error message.